### PR TITLE
fix: protect dashboard routes with Clerk authentication

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,10 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) await auth.protect();
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
- Added createRouteMatcher to identify protected routes
- Configured middleware to require authentication for /dashboard and all sub-routes
- Users must now be logged in to access any dashboard pages

Fixes #5