### PR TITLE
fix: replace custom buttons with Shadcn UI Button components in navbar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import {
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { Button } from "@/components/ui/button";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -47,14 +48,14 @@ export default function RootLayout({
             <header className="flex justify-end gap-4 p-4">
               <SignedOut>
                 <SignInButton mode="modal">
-                  <button className="px-4 py-2  text-white rounded-md hover:text-indigo-700 font-bold transition">
+                  <Button variant="outline" size="default">
                     Sign In
-                  </button>
+                  </Button>
                 </SignInButton>
                 <SignUpButton mode="modal">
-                  <button className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 font-bold transition-all">
+                  <Button variant="default" size="default">
                     Sign Up
-                  </button>
+                  </Button>
                 </SignUpButton>
               </SignedOut>
               <SignedIn>


### PR DESCRIPTION
Replaced the custom styled Sign In and Sign Up buttons in the navbar with Shadcn UI Button components as requested. No duplicate buttons exist.

- Sign In button uses variant="outline"
- Sign Up button uses variant="default"
- Both buttons properly styled with Shadcn UI theming